### PR TITLE
feat: reconnect websocket on close

### DIFF
--- a/src/lanyard.ts
+++ b/src/lanyard.ts
@@ -3,11 +3,12 @@ import {
 	LanyardData,
 	LanyardOptions,
 	LanyardResponse,
+	LanyardSWRMultiple,
 	LanyardSWRSingle,
 	LanyardWebsocket,
-	LanyardSWRMultiple,
 } from "./types";
 import { useEffect, useState } from "react";
+
 import useSWR from "swr";
 
 export const useLanyard = (
@@ -26,44 +27,53 @@ export const useLanyard = (
 					"Browser doesn't support WebSocket connections.",
 				);
 
-			const socket = new WebSocket(WEBSOCKET_URL);
-			setWebsocket(socket);
-
 			let key = "subscribe_to_id";
 			if (typeof options.userId === "object") key = "subscribe_to_ids";
 
 			let heartbeat: NodeJS.Timeout;
+			let socket: WebSocket;
 
-			socket.addEventListener("open", () => {
-				socket.send(
-					JSON.stringify({
-						op: 2,
-						d: {
-							[key]: options.userId,
-						},
-					}),
-				);
+			const connectWebsocket = () => {
+				socket = new WebSocket(WEBSOCKET_URL);
+				setWebsocket(socket);
+				setLoading(true);
 
-				heartbeat = setInterval(() => {
+				socket.addEventListener("open", () => {
 					socket.send(
 						JSON.stringify({
-							op: 3,
+							op: 2,
+							d: {
+								[key]: options.userId,
+							},
 						}),
 					);
-				}, 30000);
-			});
 
-			socket.addEventListener("message", ({ data }) => {
-				const { t, d } = JSON.parse(data) as {
-					t: "INIT_STATE" | "PRESENCE_UPDATE";
-					d: LanyardData;
-				};
+					heartbeat = setInterval(() => {
+						socket.send(
+							JSON.stringify({
+								op: 3,
+							}),
+						);
+					}, 30000);
+				});
 
-				if (t === "INIT_STATE" || t === "PRESENCE_UPDATE") {
-					setStatus(d || ({} as LanyardData));
-					if (loading) setLoading(false);
-				}
-			});
+				socket.addEventListener("message", ({ data }) => {
+					const { t, d } = JSON.parse(data) as {
+						t: "INIT_STATE" | "PRESENCE_UPDATE";
+						d: LanyardData;
+					};
+					if (t === "INIT_STATE" || t === "PRESENCE_UPDATE") {
+						setStatus(d || ({} as LanyardData));
+						if (loading) setLoading(false);
+					}
+				});
+
+				socket.addEventListener("close", () => {
+					connectWebsocket();
+				});
+			};
+
+			connectWebsocket();
 
 			return () => {
 				clearInterval(heartbeat);


### PR DESCRIPTION
from my personal testing, this reconnected the websocket when it got disconnected.

It's possible the `socket` variable can be removed for just the `websocket` from the useState, but since that's `WebSocket | undefined` it's a little harder to work with.

LMK what you think!