### PR TITLE
feat: return types based on input parameters

### DIFF
--- a/src/lanyard.ts
+++ b/src/lanyard.ts
@@ -10,9 +10,15 @@ import { API_URL, WEBSOCKET_URL } from "./constants";
 import { useEffect, useState } from "react";
 import useSWR from "swr";
 
-export const useLanyard = (
-	options: LanyardOptions,
-): LanyardSWRSingle | LanyardSWRMultiple | LanyardWebsocket => {
+type useLanyard<T> = 
+	T extends { socket: true } ? LanyardWebsocket :
+	T extends { userId: string } ? LanyardSWRSingle :
+	T extends { userId: string[] } ? LanyardSWRMultiple :
+	never
+
+export const useLanyard = <T extends LanyardOptions>(
+	options: T,
+): useLanyard<T> => {
 	if (options.socket) {
 		const [status, setStatus] = useState<LanyardData>();
 		const [websocket, setWebsocket] = useState<WebSocket>();
@@ -81,7 +87,7 @@ export const useLanyard = (
 			};
 		}, []);
 
-		return { websocket, loading, status };
+		return { websocket, loading, status } as useLanyard<T>;
 	} else {
 		if (typeof options.userId === "string") {
 			return useSWR<LanyardResponse>(
@@ -96,7 +102,7 @@ export const useLanyard = (
 
 					return body;
 				},
-			);
+			) as useLanyard<T>;
 		} else {
 			return useSWR<LanyardResponse[]>(
 				`lanyard_${options.userId.join("_")}`,
@@ -114,7 +120,7 @@ export const useLanyard = (
 
 					return responseArray;
 				},
-			);
+			) as useLanyard<T>;
 		}
 	}
 };


### PR DESCRIPTION
This should make it so that if `socket` is set to `true` the return types will always be `LanyardWebsocket`  with the same concept applying to `string` / `string[]` for the swr types.

The syntax isn't the prettiest in the world, but if this functions how I intended, it makes it easier for the developer to use.
This is what my [project](https://github.com/Hexiro/hexiro.me/blob/55b036e7d0bc2a96d8edd625ed138e7fc7ad8105/src/components/lanyard/Lanyard.tsx#L15) looks like currently, but it'd be better if the type assertion could be ommited.

```ts
const { loading, status } = useLanyard({
    userId: Discord,
    socket: true,
}) as LanyardWebsocket;
```
lmk what you think!

