### PR TITLE
Add Pomelo support (new username system) and bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "react-use-lanyard",
-	"version": "0.3.0",
+	"version": "0.3.1",
 	"main": "dist",
 	"typings": "dist",
 	"repository": {

--- a/src/types.ts
+++ b/src/types.ts
@@ -127,6 +127,7 @@ export interface Emoji {
 
 export interface DiscordUser {
 	username: string;
+	global_name: string | null;
 	public_flags: number;
 	id: string;
 	discriminator: string;


### PR DESCRIPTION
Added missing Pomelo support:

- `global_name` DiscordUser