### PR TITLE
fix: update PartySize to a tuple of numbers

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -100,12 +100,7 @@ export interface Activity {
 
 export interface Party {
 	id: string;
-	size?: PartySize;
-}
-
-export interface PartySize {
-	current_size: number;
-	max_size: number;
+	size?: [number, number];
 }
 
 export interface Assets {


### PR DESCRIPTION
`party` `size` now returns a tuple (technically an array, but always of size two) of two integers instead of an object with two properties. (Party size/Max size)

https://discord.com/developers/docs/topics/gateway-events#activity-object-activity-party

![image](https://github.com/user-attachments/assets/d91ef712-8d60-43d0-aa69-31460f21ef5e)

I noticed this when working on a project.
